### PR TITLE
Add generic-x86-64 machine

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -7,6 +7,7 @@
     "qemux86-64": "2021.3.4",
     "qemuarm": "2021.3.4",
     "qemuarm-64": "2021.3.4",
+    "generic-x86-64": "2021.3.4",
     "intel-nuc": "2021.3.4",
     "raspberrypi": "2021.3.4",
     "raspberrypi2": "2021.3.4",
@@ -34,6 +35,7 @@
     "odroid-c4": "5.12",
     "odroid-n2": "5.12",
     "odroid-xu4": "5.12",
+    "generic-x86-64": "6.0.dev20210311",
     "intel-nuc": "5.12"
   },
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/hassos_{board}-{version}.raucb",

--- a/dev.json
+++ b/dev.json
@@ -7,6 +7,7 @@
     "qemux86-64": "2021.4.0.dev20210317",
     "qemuarm": "2021.4.0.dev20210317",
     "qemuarm-64": "2021.4.0.dev20210317",
+    "generic-x86-64": "2021.4.0.dev20210317",
     "intel-nuc": "2021.4.0.dev20210317",
     "raspberrypi": "2021.4.0.dev20210317",
     "raspberrypi2": "2021.4.0.dev20210317",
@@ -34,6 +35,7 @@
     "odroid-c4": "5.12",
     "odroid-n2": "5.12",
     "odroid-xu4": "5.12",
+    "generic-x86-64": "6.0.dev20210311",
     "intel-nuc": "5.12"
   },
   "ota": "https://os-builds.home-assistant.io/{version}/hassos_{board}-{version}.raucb",

--- a/stable.json
+++ b/stable.json
@@ -7,6 +7,7 @@
     "qemux86-64": "2021.3.4",
     "qemuarm": "2021.3.4",
     "qemuarm-64": "2021.3.4",
+    "generic-x86-64": "2021.3.4",
     "intel-nuc": "2021.3.4",
     "raspberrypi": "2021.3.4",
     "raspberrypi2": "2021.3.4",
@@ -34,6 +35,7 @@
     "odroid-c4": "5.12",
     "odroid-n2": "5.12",
     "odroid-xu4": "5.12",
+    "generic-x86-64": "6.0.dev20210311",
     "intel-nuc": "5.12"
   },
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/hassos_{board}-{version}.raucb",


### PR DESCRIPTION
Add generic-x86-64 machine for Home Assistant Core and Home Assistant
OS. Note that currently there is no official release of the OS. Still
adding the latest nightly build will make sure that the OS release will
automatically set to a valid version once we release the first version
of Home Assistant OS with generic-x86-64 machine.