### PR TITLE
Push 2021.03.9 to stable

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2021.03.6",
+  "supervisor": "2021.03.9",
   "homeassistant": {
     "default": "2021.3.4",
     "qemux86": "2021.3.4",


### PR DESCRIPTION
Run now a week without any sentry issues and also 2021.03.8 run before without issues (at least no issue which we could fix).
https://sentry.io/organizations/home-assistant-io/issues/?project=5370612&query=+release%3A2021.03.9&statsPeriod=14d

Please merge after approval