### PR TITLE
Push Supervisor 2021.04.0 to stable

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2021.03.9",
+  "supervisor": "2021.04.0",
   "homeassistant": {
     "default": "2021.4.4",
     "qemux86": "2021.4.4",


### PR DESCRIPTION
Run fine on beta for 7 Days. All new issues are fixed, there was just one with a missing signature of an exist plugin