### PR TITLE
Use 64-bit variant for RPi 3

### DIFF
--- a/rpi-imager-haos.json
+++ b/rpi-imager-haos.json
@@ -1,7 +1,7 @@
 {
     "os_list": [
         {
-            "name": "Home Assistant OS 5.13 (Pi 4 - 64-bit)",
+            "name": "Home Assistant OS 5.13 (RPi 4/400)",
             "description": "Open-source home automation platform with a focus on local control and privacy.",
             "url": "https://github.com/home-assistant/operating-system/releases/download/5.13/hassos_rpi4-64-5.13.img.xz",
             "icon": "https://version.home-assistant.io/rpi-imager-haos.png",
@@ -12,15 +12,15 @@
             "image_download_sha256": "811df3f5ca79aeff96619515731c434f9446d6384f6f620202dd9a044c174c0b"
         },
         {
-            "name": "Home Assistant OS 5.13 (Pi 3 - 32-bit)",
+            "name": "Home Assistant OS 5.13 (RPi 3)",
             "description": "Open-source home automation platform with a focus on local control and privacy.",
-            "url": "https://github.com/home-assistant/operating-system/releases/download/5.13/hassos_rpi3-5.13.img.xz",
+            "url": "https://github.com/home-assistant/operating-system/releases/download/5.13/hassos_rpi3-64-5.13.img.xz",
             "icon": "https://version.home-assistant.io/rpi-imager-haos.png",
             "extract_size": 2147483648,
-            "extract_sha256": "1911220032792261f6e63a96e500c76dc85b775ac922b51a6c810666876f22b8",
-            "image_download_size": 257702916,
+            "extract_sha256": "496a5448030174d61f9b7911af2fa72ab603a521173b5cbd9a0dbcddfd3119a6",
+            "image_download_size": 264364648,
             "release_date": "2021-04-01",
-            "image_download_sha256": "a41e9429b5833e7776b180ec24cf7a90fce429480c2e3b8c574bcc62216c243e"
+            "image_download_sha256": "8984eab5308346bd1442acaa43585a9afba9204d20186007f86120eed4244908"
         }
     ]
 }


### PR DESCRIPTION
Also use the same syntax to denote the Raspberry Pi compatibility like other images are using (e.g. Ubuntu)