### PR TITLE
Fix image URL's

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -50,7 +50,7 @@
     "cli": "ghcr.io/home-assistant/{arch}-hassio-cli",
     "audio": "ghcr.io/home-assistant/{arch}-hassio-audio",
     "dns": "ghcr.io/home-assistant/{arch}-hassio-dns",
-    "observer": "ghcr.io/home-assistant/{arch}-hassio-observer",
+    "observer": "homeassistant/{arch}-hassio-observer",
     "multicast": "ghcr.io/home-assistant/{arch}-hassio-multicast"
   }
 }

--- a/stable.json
+++ b/stable.json
@@ -50,7 +50,7 @@
     "cli": "ghcr.io/home-assistant/{arch}-hassio-cli",
     "audio": "ghcr.io/home-assistant/{arch}-hassio-audio",
     "dns": "ghcr.io/home-assistant/{arch}-hassio-dns",
-    "observer": "ghcr.io/home-assistant/{arch}-hassio-observer",
+    "observer": "homeassistant/{arch}-hassio-observer",
     "multicast": "ghcr.io/home-assistant/{arch}-hassio-multicast"
   }
 }


### PR DESCRIPTION
Observer only exist for dev on ghcr.io

Fixes home-assistant/plugin-observer#45