### PR TITLE
Add Khadas VIM3 machine support

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -9,6 +9,7 @@
     "qemuarm-64": "2021.8.0b9",
     "generic-x86-64": "2021.8.0b9",
     "intel-nuc": "2021.8.0b9",
+    "khadas-vim3": "2021.8.0b9",
     "raspberrypi": "2021.8.0b9",
     "raspberrypi2": "2021.8.0b9",
     "raspberrypi3": "2021.8.0b9",

--- a/dev.json
+++ b/dev.json
@@ -9,6 +9,7 @@
     "qemuarm-64": "2021.9.0.dev20210803",
     "generic-x86-64": "2021.9.0.dev20210803",
     "intel-nuc": "2021.9.0.dev20210803",
+    "khadas-vim3": "2021.9.0.dev20210803",
     "raspberrypi": "2021.9.0.dev20210803",
     "raspberrypi2": "2021.9.0.dev20210803",
     "raspberrypi3": "2021.9.0.dev20210803",

--- a/stable.json
+++ b/stable.json
@@ -9,6 +9,7 @@
     "qemuarm-64": "2021.7.4",
     "generic-x86-64": "2021.7.4",
     "intel-nuc": "2021.7.4",
+    "khadas-vim3": "2021.8.0b9",
     "raspberrypi": "2021.7.4",
     "raspberrypi2": "2021.7.4",
     "raspberrypi3": "2021.7.4",


### PR DESCRIPTION
Currently this adds the machine only for the Core container as there is no official OS build available yet.