### PR TITLE
Revert to 6.2 for platforms which use Linux 5.10.61

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -23,7 +23,7 @@
     "odroid-xu": "2021.9.3"
   },
   "hassos": {
-    "ova": "6.3",
+    "ova": "6.2",
     "rpi": "6.3",
     "rpi0-w": "6.3",
     "rpi2": "6.3",
@@ -31,13 +31,13 @@
     "rpi3-64": "6.3",
     "rpi4": "6.3",
     "rpi4-64": "6.3",
-    "tinker": "6.3",
-    "odroid-c2": "6.3",
-    "odroid-c4": "6.3",
-    "odroid-n2": "6.3",
-    "odroid-xu4": "6.3",
-    "generic-x86-64": "6.3",
-    "intel-nuc": "6.3"
+    "tinker": "6.2",
+    "odroid-c2": "6.2",
+    "odroid-c4": "6.2",
+    "odroid-n2": "6.2",
+    "odroid-xu4": "6.2",
+    "generic-x86-64": "6.2",
+    "intel-nuc": "6.2"
   },
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2021.08.1",


### PR DESCRIPTION
Linux 5.10.61 seems to have communication issues with CH340 based
devices. Since those are used quite a bit for Zigbee dongles etc. let's
pull the release from the stable channel.