### PR TITLE
Bump Supervisor to 2021.10.8

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2021.10.6",
+  "supervisor": "2021.10.8",
   "homeassistant": {
     "default": "2021.10.6",
     "qemux86": "2021.10.6",


### PR DESCRIPTION
<https://github.com/home-assistant/supervisor/releases/tag/2021.10.7>
<https://github.com/home-assistant/supervisor/releases/tag/2021.10.8>