### PR TITLE
Bump Supervisor to 2021.12.2

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2021.12.1",
+  "supervisor": "2021.12.2",
   "homeassistant": {
     "default": "2021.12.1",
     "qemux86": "2021.12.1",


### PR DESCRIPTION
<https://github.com/home-assistant/supervisor/releases/tag/2021.12.2>