### PR TITLE
Revert back to OS 7.2 for generic-x86-64/ova

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -23,7 +23,7 @@
     "odroid-xu": "2022.2.3"
   },
   "hassos": {
-    "ova": "7.3",
+    "ova": "7.2",
     "rpi2": "7.3",
     "rpi3": "7.3",
     "rpi3-64": "7.3",
@@ -35,7 +35,7 @@
     "odroid-c4": "7.3",
     "odroid-n2": "7.3",
     "odroid-xu4": "7.3",
-    "generic-x86-64": "7.3",
+    "generic-x86-64": "7.2",
     "intel-nuc": "7.3",
     "khadas-vim3": "7.3"
   },


### PR DESCRIPTION
Multiple reports of stability issues on x86-64
https://github.com/home-assistant/operating-system/issues/1739