### PR TITLE
Revert "Bump dns to 2022.02.0"

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -41,7 +41,7 @@
   },
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2021.12.0",
-  "dns": "2022.02.0",
+  "dns": "2021.06.0",
   "audio": "2021.07.0",
   "multicast": "2022.02.0",
   "observer": "2021.10.0",


### PR DESCRIPTION
This reverts commit 1e690845bfc27d449a6378ee1f994ab38fbe97d7.