### PR TITLE
Update DNS plugin to 2022.04.1

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -42,7 +42,7 @@
   },
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2022.05.0",
-  "dns": "2021.06.0",
+  "dns": "2022.04.1",
   "audio": "2022.04.0",
   "multicast": "2022.02.0",
   "observer": "2021.10.0",


### PR DESCRIPTION
Update version on stable. Includes all recent DNS changes (systemd-resolved for mdns, fallback DNS changes, servfail elimination, etc)