### PR TITLE
Supervisor 2022.05.2

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2022.05.1",
+  "supervisor": "2022.05.2",
   "homeassistant": {
     "default": "2022.5.4",
     "qemux86": "2022.5.4",


### PR DESCRIPTION
https://github.com/home-assistant/supervisor/releases/tag/2022.05.2

I guess that should be safe?