### PR TITLE
Bump audio stable to 2022.07.0

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -50,7 +50,7 @@
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2022.06.0",
   "dns": "2022.04.1",
-  "audio": "2022.05.0",
+  "audio": "2022.07.0",
   "multicast": "2022.02.0",
   "observer": "2021.10.0",
   "image": {


### PR DESCRIPTION
Bumping this without a corresponding supervisor bump since there were some issues identified with supervisor 2022.07.1. This will effectively turn off debug logging entirely in audio at the cost of a single warning log at start of the plugin complaining about the lack of a configuration file. Once supervisor is bumped the warning will go away and debug logging for the plugin can be enabled on demand.