### PR TITLE
Bump supervisor stable to `2022.08.4`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2022.08.3",
+  "supervisor": "2022.08.4",
   "homeassistant": {
     "default": "2022.8.6",
     "qemux86": "2022.8.6",


### PR DESCRIPTION
Has some important network and watchdog fixes and not seeing any issues in sentry so want to push to stable.