### PR TITLE
Revert "Supervisor stable to `2023.03.3` (#282)"

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2023.03.3",
+  "supervisor": "2023.03.2",
   "homeassistant": {
     "default": "2023.3.6",
     "qemux86": "2023.3.6",


### PR DESCRIPTION
This reverts commit edb90c65b9b43213438bfbb38ddd5aa37058db41.

There are two major issues currently: https://github.com/home-assistant/supervisor/issues/4216 and https://github.com/home-assistant/supervisor/issues/4220.