### PR TITLE
Add capability chown to supervisor AA

### DIFF
--- a/apparmor.txt
+++ b/apparmor.txt
@@ -13,6 +13,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
   capability net_bind_service,
   capability dac_read_search,
   capability dac_override,
+  capability chown,
 
   /bin/** ix,
   /usr/bin/** ix,


### PR DESCRIPTION
It appears that tar extract does a [chown](https://github.com/python/cpython/blob/daf22ca7f941faac50b437e1c216732eae38a9e9/Lib/tarfile.py#L2418) on files. This doesn't normally come up for supervisor because on HAOS nearly everything runs as root. But it can come up when moving a backup from core/container to HAOS, as per https://github.com/home-assistant/supervisor/issues/4344

Adding `chown` capability to account for this.