### PR TITLE
Bump audio plug-in to 2023.04.2

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -53,7 +53,7 @@
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2023.05.0",
   "dns": "2022.04.1",
-  "audio": "2023.04.1",
+  "audio": "2023.04.2",
   "multicast": "2022.02.0",
   "observer": "2021.10.0",
   "image": {


### PR DESCRIPTION
See [2023.04.2 changelog](https://github.com/home-assistant/plugin-audio/releases/tag/2023.04.2).