### PR TITLE
Bump Observer to 2022.10.0

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -55,7 +55,7 @@
   "dns": "2022.04.1",
   "audio": "2023.04.2",
   "multicast": "2022.02.0",
-  "observer": "2021.10.0",
+  "observer": "2022.10.0",
   "image": {
     "core": "homeassistant/{machine}-homeassistant",
     "supervisor": "homeassistant/{arch}-hassio-supervisor",


### PR DESCRIPTION
This has been on stable for quite a while and seems to work fine here on latest OS.