### PR TITLE
Drop obsolete Intel NUC board

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -40,7 +40,6 @@
     "odroid-xu4": "10.3",
     "generic-x86-64": "10.3",
     "generic-aarch64": "10.3",
-    "intel-nuc": "10.3",
     "khadas-vim3": "10.3"
   },
   "hassos-upgrade": {

--- a/dev.json
+++ b/dev.json
@@ -40,7 +40,6 @@
     "odroid-xu4": "11.0.dev20230622",
     "generic-x86-64": "11.0.dev20230622",
     "generic-aarch64": "11.0.dev20230622",
-    "intel-nuc": "11.0.dev20230622",
     "khadas-vim3": "11.0.dev20230622"
   },
   "ota": "https://os-builds.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",


### PR DESCRIPTION
The intel-nuc board has been replaced with generic-x86-64. It is already gone from stable, cleanup beta annd dev as well.