### PR TITLE
Update apparmor profile to support git in Alpine 3.18

### DIFF
--- a/apparmor.txt
+++ b/apparmor.txt
@@ -72,7 +72,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
     signal (receive) set=(term),
 
     /bin/busybox ix,
-    /usr/bin/git mr,
+    /usr/bin/git mrx,
     /usr/libexec/git-core/* ix,
 
     deny /data/homeassistant rw,


### PR DESCRIPTION
It seems that Alpine 3.18 uses symlinks back to the original binary like so:

```
# ls -la /usr/libexec/git-core/
total 2532
drwxr-xr-x    3 root     root          4096 Oct 20 02:03 .
drwxr-xr-x    3 root     root          4096 Oct 20 02:03 ..
lrwxrwxrwx    1 root     root            13 Oct 20 02:03 git -> ../../bin/git
lrwxrwxrwx    1 root     root            13 Oct 20 02:03 git-add -> ../../bin/git
...
```

Adding permissions to exec git resolves `fatal: cannot exec 'remote-https': Permission denied` errors in Supervisor.