### PR TITLE
Revert "Update apparmor profile to support git in Alpine 3.18 (#329)"

### DIFF
--- a/apparmor.txt
+++ b/apparmor.txt
@@ -72,7 +72,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
     signal (receive) set=(term),
 
     /bin/busybox ix,
-    /usr/bin/git mrx,
+    /usr/bin/git mr,
     /usr/libexec/git-core/* ix,
 
     deny /data/homeassistant rw,


### PR DESCRIPTION
This reverts commit b5ef092a6cf6c4940232430a19a1776c5aec9b8c.

It seems that this profile leads to parsing errors on some platforms.