### PR TITLE
Mark Supervisor 2023.11.3 stable

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2023.11.0",
+  "supervisor": "2023.11.3",
   "homeassistant": {
     "default": "2023.11.2",
     "qemux86": "2023.11.2",


### PR DESCRIPTION
Marks the 2023.11.3 release of the Supervisor as stable.

Release notes since the last stable:

- https://github.com/home-assistant/supervisor/releases/tag/2023.11.1
- https://github.com/home-assistant/supervisor/releases/tag/2023.11.2
- https://github.com/home-assistant/supervisor/releases/tag/2023.11.3