### PR TITLE
Use dev build URL on beta channel

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -56,7 +56,7 @@
     "4": "4.20",
     "3": "3.13"
   },
-  "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
+  "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2023.11.0",
   "dns": "2023.06.2",
   "audio": "2023.12.0",


### PR DESCRIPTION
OS images on the beta channel are typically stored on GitHub. However, we do redirect non-dev builds automatically to the GitHub location. Using the dev URL on the beta channel allows to update to a dev builds for testing using `ha os update --version 11.5.dev202401251.