### PR TITLE
Add HAOS Odroid-m1s board

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -40,6 +40,7 @@
     "odroid-c2": "12.0.rc1",
     "odroid-c4": "12.0.rc1",
     "odroid-m1": "12.0.rc1",
+    "odroid-m1s": "12.0.rc1",
     "odroid-n2": "12.0.rc1",
     "odroid-xu4": "12.0.rc1",
     "generic-x86-64": "12.0.rc1",

--- a/dev.json
+++ b/dev.json
@@ -40,6 +40,7 @@
     "odroid-c2": "12.0.dev20240214",
     "odroid-c4": "12.0.dev20240214",
     "odroid-m1": "12.0.dev20240214",
+    "odroid-m1s": "12.0.dev20240214",
     "odroid-n2": "12.0.dev20240214",
     "odroid-xu4": "12.0.dev20240214",
     "generic-x86-64": "12.0.dev20240214",

--- a/stable.json
+++ b/stable.json
@@ -40,6 +40,7 @@
     "odroid-c2": "11.5",
     "odroid-c4": "11.5",
     "odroid-m1": "11.5",
+    "odroid-m1s": "12.0.rc1",
     "odroid-n2": "11.5",
     "odroid-xu4": "11.5",
     "generic-x86-64": "11.5",


### PR DESCRIPTION
Support for Odroid-m1s board has been added in HAOS 12.0rc1 

https://github.com/home-assistant/operating-system/releases/tag/12.0.rc1