### PR TITLE
Bump cli and dns plug-in on stable channel

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -59,8 +59,8 @@
     "3": "3.13"
   },
   "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
-  "cli": "2024.02.1",
-  "dns": "2023.06.2",
+  "cli": "2024.03.1",
+  "dns": "2024.03.0",
   "audio": "2023.12.0",
   "multicast": "2023.06.2",
   "observer": "2023.06.0",


### PR DESCRIPTION
Bump the cli plug-in to 2024.03.1 and dns plug-in to 2024.03.0.