### PR TITLE
Update cosign to v2.2.3

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-  COSIGN_VERSION: "v2.0.2"
+  COSIGN_VERSION: "v2.2.3"
   SIGNED_FILES: "apparmor.txt apparmor_beta.txt apparmor_dev.txt apparmor_stable.txt beta.json dev.json stable.json"
 
 jobs:


### PR DESCRIPTION
The current version of cosign (v2.0.2) isn't working anymore with the server side infrastructure. See https://blog.sigstore.dev/tuf-root-update/.