### PR TITLE
Create dynamic build matrix for files to sign

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -54,17 +54,20 @@ jobs:
       id: generate_matrix
       with:
         script: |
+          files_to_sign = []
+          const all_files = "${{ env.SIGNED_FILES }}".split(' ')
           if ("${{ github.event_name }}" == "push") {
             const changed_files = JSON.parse('${{ steps.changed_files_push.outputs.all }}')
-            const all_files = "${{ env.SIGNED_FILES }}".split(' ')
             // Sign all files in case this workflow changes.
             if (changed_files.includes(".github/workflows/version.yml")) {
-              return { "path": all_files }
+              files_to_sign = all_files
             }
-            return { "path": changed_files }
+            files_to_sign = changed_files.filter(value => all_files.includes(value))
           } else {
-            return { "path": "${{ github.event.inputs.files }}".split(' ') }
+            input_files = "${{ github.event.inputs.files }}".split(' ')
+            files_to_sign = input_files.filter(value => all_files.includes(value))
           }
+          return { "path": files_to_sign }
   
   signing:
     name: Sign ${{ matrix.path }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -37,8 +37,8 @@ jobs:
     needs: ["lint"]
     runs-on: ubuntu-latest
     outputs:
-      files: ${{ steps.changed_files.outputs.files }}
-      sign_matrix: ${{ steps.generate_matrix.outputs.result }}
+      files: ${{ steps.calc_file_list.outputs.changed_files }}
+      sign_matrix: ${{ steps.calc_file_list.outputs.result }}
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4
@@ -50,22 +50,24 @@ jobs:
       with:
         format: 'json'
 
-    - name: Create sign matrix
+    - name: Calculate files to sign and push
       uses: actions/github-script@v7
-      id: generate_matrix
+      id: calc_file_list
       with:
         script: |
-          const all_files = "${{ env.SIGNED_FILES }}".split(' ')
+          const signed_files = "${{ env.SIGNED_FILES }}".split(' ')
           if ("${{ github.event_name }}" === "push") {
-            const changed_files = JSON.parse('${{ steps.changed_files_push.outputs.all }}')
+            changed_files = JSON.parse('${{ steps.changed_files_push.outputs.all }}')
             // Sign all files in case this workflow changes.
             if (changed_files.includes(".github/workflows/version.yml")) {
-              return all_files
+              changed_files = [...new Set([...changed_files, ...signed_files])]
             }
-            return changed_files.filter(value => all_files.includes(value))
+            core.setOutput("changed_files", changed_files.join(' '))
+            return changed_files.filter(value => signed_files.includes(value))
           } else {
             input_files = "${{ github.event.inputs.files }}".split(' ')
-            return input_files.filter(value => all_files.includes(value))
+            core.setOutput("changed_files", input_files.join(' '))
+            return input_files.filter(value => signed_files.includes(value))
           }
   
   signing:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         script: |
           const all_files = "${{ env.SIGNED_FILES }}".split(' ')
-          if ("${{ github.event_name }}" == "push") {
+          if ("${{ github.event_name }}" === "push") {
             const changed_files = JSON.parse('${{ steps.changed_files_push.outputs.all }}')
             // Sign all files in case this workflow changes.
             if (changed_files.includes(".github/workflows/version.yml")) {

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -37,7 +37,7 @@ jobs:
     needs: ["lint"]
     runs-on: ubuntu-latest
     outputs:
-      files: ${{ steps.changed_files.outputs.files }}
+      sign_matrix: ${{ steps.generate_matrix.outputs.result }}
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4
@@ -45,16 +45,17 @@ jobs:
     - name: Get changed files for push
       if: github.event_name == 'push'
       id: changed_files_push
-      uses: jitterbit/get-changed-files@v1
+      uses: masesgroup/retrieve-changed-files@v3.0.0
+      with:
+        format: 'json'
 
-    - name: Get changed files
-      id: changed_files
-      run: |
-        if [[ ${{ github.event_name }} == "push" ]]; then
-          echo "files=${{ steps.changed_files_push.outputs.all }}" >> $GITHUB_OUTPUT
-        else
-          echo "files=${{ github.event.inputs.files }}" >> $GITHUB_OUTPUT
-        fi
+    - name: Create sign matrix
+      uses: actions/github-script@v7
+      id: generate_matrix
+      with:
+        script: |
+          const files = ${{ steps.changed_files_push.outputs.all }}
+          return { "path": files }
   
   signing:
     name: Sign ${{ matrix.path }}
@@ -65,29 +66,12 @@ jobs:
       id-token: write
       packages: write
     strategy:
-      matrix:
-        path:
-          - stable.json
-          - beta.json
-          - dev.json
-          - apparmor.txt
-          - apparmor_stable.txt
-          - apparmor_beta.txt
-          - apparmor_dev.txt
+      matrix: ${{ fromJson(needs.prepare.outputs.sign_matrix) }}
     steps:
-      - name: Check
-        id: check
-        run: |
-          if [[ "${{ needs.prepare.outputs.files }}" =~ ${{ matrix.path }} ]]; then
-            echo "sign=yes" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout the repository
-        if: steps.check.outputs.sign == 'yes'
         uses: actions/checkout@v4
       
       - name: Login to GitHub Container Registry
-        if: steps.check.outputs.sign == 'yes'
         uses: docker/login-action@v3.1.0
         with:
           registry: ghcr.io
@@ -95,33 +79,27 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       
       - uses: sigstore/cosign-installer@main
-        if: steps.check.outputs.sign == 'yes'
         with:
           cosign-release: ${{ env.COSIGN_VERSION }}
 
       - name: Setup Python version ${{ env.PYTHON_VERSION }}
-        if: steps.check.outputs.sign == 'yes'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install AWS CLI
-        if: steps.check.outputs.sign == 'yes'
         run: pip install awscli
       
       - name: Upload file
-        if: steps.check.outputs.sign == 'yes'
         run: |
           cosign upload blob -f ${{ matrix.path }} ghcr.io/home-assistant/version/${{ matrix.path }}
 
       - name: Sign Cosign
-        if: steps.check.outputs.sign == 'yes'
         run: |
           cosign sign --yes ghcr.io/home-assistant/version/${{ matrix.path }}
           cosign sign-blob --yes ${{ matrix.path }} --bundle ${{ matrix.path }}.sig
 
       - name: Upload signature
-        if: steps.check.outputs.sign == 'yes'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -37,6 +37,7 @@ jobs:
     needs: ["lint"]
     runs-on: ubuntu-latest
     outputs:
+      files: ${{ steps.changed_files.outputs.files }}
       sign_matrix: ${{ steps.generate_matrix.outputs.result }}
     steps:
     - name: Checkout the repository

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -14,6 +14,7 @@ on:
     - '*.txt'
     - '*.json'
     - '*.png'
+    - '.github/workflows/version.yml'
 
 env:
   PYTHON_VERSION: "3.10"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       files:
-        description: 'File(s) to run action against'
+        description: 'File(s) to run action against (space separated)'
         required: true
   pull_request:
     branches: ["master"]
@@ -54,8 +54,17 @@ jobs:
       id: generate_matrix
       with:
         script: |
-          const files = ${{ steps.changed_files_push.outputs.all }}
-          return { "path": files }
+          if ("${{ github.event_name }}" == "push") {
+            const changed_files = JSON.parse('${{ steps.changed_files_push.outputs.all }}')
+            const all_files = "${{ env.SIGNED_FILES }}".split(' ')
+            // Sign all files in case this workflow changes.
+            if (changed_files.includes(".github/workflows/version.yml")) {
+              return { "path": all_files }
+            }
+            return { "path": changed_files }
+          } else {
+            return { "path": "${{ github.event.inputs.files }}".split(' ') }
+          }
   
   signing:
     name: Sign ${{ matrix.path }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -54,31 +54,30 @@ jobs:
       id: generate_matrix
       with:
         script: |
-          files_to_sign = []
           const all_files = "${{ env.SIGNED_FILES }}".split(' ')
           if ("${{ github.event_name }}" == "push") {
             const changed_files = JSON.parse('${{ steps.changed_files_push.outputs.all }}')
             // Sign all files in case this workflow changes.
             if (changed_files.includes(".github/workflows/version.yml")) {
-              files_to_sign = all_files
+              return all_files
             }
-            files_to_sign = changed_files.filter(value => all_files.includes(value))
+            return changed_files.filter(value => all_files.includes(value))
           } else {
             input_files = "${{ github.event.inputs.files }}".split(' ')
-            files_to_sign = input_files.filter(value => all_files.includes(value))
+            return input_files.filter(value => all_files.includes(value))
           }
-          return { "path": files_to_sign }
   
   signing:
     name: Sign ${{ matrix.path }}
     needs: ["prepare"]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.prepare.outputs.sign_matrix != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       packages: write
     strategy:
-      matrix: ${{ fromJson(needs.prepare.outputs.sign_matrix) }}
+      matrix:
+        path: ${{ fromJson(needs.prepare.outputs.sign_matrix) }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Dynamically build the matrix depending on what needs to be signed.

Also replace `jitterbit/get-changed-files` with a drop in replacement which doesn't lead to warning.

Finally, if the workflow changed, resign all the files. This is helpful when changing something in the workflow which influences signing.