### PR TITLE
AppArmor: Explicitly allow netlink raw socket for Supervisor

### DIFF
--- a/apparmor_beta.txt
+++ b/apparmor_beta.txt
@@ -4,8 +4,12 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/python>
 
-  network,
-  deny network raw,
+  network unix stream,
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network inet6 dgram,
+  network netlink raw,
 
   signal (send) set=(kill,term,int,hup,cont),
 

--- a/apparmor_dev.txt
+++ b/apparmor_dev.txt
@@ -4,8 +4,12 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/python>
 
-  network,
-  deny network raw,
+  network unix stream,
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network inet6 dgram,
+  network netlink raw,
 
   signal (send) set=(kill,term,int,hup,cont),
 


### PR DESCRIPTION
The Supervisor uses netlink raw sockets to get access to udev events sent through netlink. Technically, the rules so far have denied all raw sockets. However, in practice it seems that netlink raw sockets have still been working.

For unknown reasons, in Debian Bookworm that behavior changed: The rule now also denies netlink raw sockets.

This new ruleset starts off with the default setting (where almost everything seems to be denied), and enables explicitly what is needed in Supervisor. In tests this ruleset worked on Home Assistant OS as well as Debian Bookworm.

Fixes: https://github.com/home-assistant/supervisor/issues/4381