### PR TITLE
AppArmor: Explicitly allow netlink raw socket for Supervisor on stable

### DIFF
--- a/apparmor_stable.txt
+++ b/apparmor_stable.txt
@@ -4,8 +4,12 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/python>
 
-  network,
-  deny network raw,
+  network unix stream,
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network inet6 dgram,
+  network netlink raw,
 
   signal (send) set=(kill,term,int,hup,cont),
 


### PR DESCRIPTION
Apply #370 to stable as well.