### PR TITLE
Revert to HAOS 12.2 on ODROID-N2/N2+

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -41,7 +41,7 @@
     "odroid-c4": "12.3",
     "odroid-m1": "12.3",
     "odroid-m1s": "12.3",
-    "odroid-n2": "12.3",
+    "odroid-n2": "12.2",
     "odroid-xu4": "12.3",
     "generic-x86-64": "12.3",
     "generic-aarch64": "12.3",


### PR DESCRIPTION
It seems that for certain folks the new build causes issues, see: https://github.com/home-assistant/operating-system/issues/3351