### PR TITLE
Run file upload even when signing was skipped

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -124,7 +124,7 @@ jobs:
   upload:
     name: Upload
     needs: ["signing", "prepare"]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: ${{ !(failure() || cancelled()) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the repository


### PR DESCRIPTION
This is required since the HAOS build workflow updates the channel version files and image metadata for Raspberry Pi Imager separately.

Fixes: https://github.com/home-assistant/operating-system/issues/3307