### PR TITLE
Use os-artifacts URL for stable's OTA updates too

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -58,7 +58,7 @@
     "4": "4.20",
     "3": "3.13"
   },
-  "ota": "https://github.com/home-assistant/operating-system/releases/download/{version}/{os_name}_{board}-{version}.raucb",
+  "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2024.07.0",
   "dns": "2024.04.0",
   "audio": "2023.12.0",


### PR DESCRIPTION
Use the same URL for OTA (= operating system's RAUC update bundles) as used on beta and dev. This will allow for updating also instances that are configured to use the stable channel to update to dev and beta versions if such version is explicitly requested. Currently it's possible the other way, but without changing at least to the beta channel, it's not possible to use beta/dev (e.g. for regression testing).