### PR TITLE
Revert "Supervisor stable to `2024.11.3` (#397)"

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2024.11.3",
+  "supervisor": "2024.11.2",
   "homeassistant": {
     "default": "2024.11.1",
     "qemux86": "2024.11.1",


### PR DESCRIPTION
This reverts commit 73b66cf0bcc34b9c049d0e65d3b1372761c21e01.

It seems that the new update logic overwhelms the GitHub container registry. Avoid more updates from starting by reverting for now.