### PR TITLE
Drop upload and signing of version files in ghcr.io

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -104,13 +104,8 @@ jobs:
       - name: Install AWS CLI
         run: pip install awscli
       
-      - name: Upload file
-        run: |
-          cosign upload blob -f ${{ matrix.path }} ghcr.io/home-assistant/version/${{ matrix.path }}
-
       - name: Sign Cosign
         run: |
-          cosign sign --yes ghcr.io/home-assistant/version/${{ matrix.path }}
           cosign sign-blob --yes ${{ matrix.path }} --bundle ${{ matrix.path }}.sig
 
       - name: Upload signature


### PR DESCRIPTION
The upload and signing of version files to ghcr.io was an experiment and is not really necessary. Let's drop it. This should unblock our CI and allow updating the version file (which is currently blocked due to the request rate limiting).