### PR TITLE
Supervisor stable to `2024.11.4`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2024.11.2",
+  "supervisor": "2024.11.4",
   "homeassistant": {
     "default": "2024.11.2",
     "qemux86": "2024.11.2",


### PR DESCRIPTION
To rollout this new version the `stable.json` has been temporarily redirected to a CloudFlare worker which slowly rolled out the new version.

Now that the rollout of Supervisor `2024.11.4` completed, we can update the `stable.json` file on our previous location as well, and tear down the redirect.