### PR TITLE
Bump dns plug-in to 2024.12.0 on stable channel

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -60,7 +60,7 @@
   },
   "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2024.09.0",
-  "dns": "2024.04.0",
+  "dns": "2024.12.0",
   "audio": "2023.12.0",
   "multicast": "2024.03.0",
   "observer": "2023.06.0",


### PR DESCRIPTION
The updated plug-in has been in the beta channel for 5 days now, without any negative reports. Let's ship this to stable.

Changelog see [plug-in DNS 2024.12.0 release](https://github.com/home-assistant/plugin-dns/releases/tag/2024.12.0).