### PR TITLE
Bump CLI and DNS plug-in to `2025.02.0`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -59,8 +59,8 @@
     "3": "3.13"
   },
   "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
-  "cli": "2024.09.0",
-  "dns": "2024.12.0",
+  "cli": "2025.02.0",
+  "dns": "2025.02.0",
   "audio": "2023.12.0",
   "multicast": "2024.03.0",
   "observer": "2023.06.0",


### PR DESCRIPTION
We've run them since a week in beta, no obvious issues been reported.

Note that there is also an update for Audio, Multicast and Observer plug-in. But let's start with these two first.