### PR TITLE
Revert OS 15.0 to 14.2 for ODROID-N2

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -41,7 +41,7 @@
     "odroid-c4": "15.0",
     "odroid-m1": "15.0",
     "odroid-m1s": "15.0",
-    "odroid-n2": "15.0",
+    "odroid-n2": "14.2",
     "odroid-xu4": "15.0",
     "generic-x86-64": "15.0",
     "generic-aarch64": "15.0",


### PR DESCRIPTION
Revert to the previous version because of missing patch [1] that causes boot failures on some eMMC modules.

[1] https://github.com/home-assistant/operating-system/issues/3938#issuecomment-2732517130