### PR TITLE
Revert OS 15.0 to 14.2 for ODROID-N2 also in beta

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -41,7 +41,7 @@
     "odroid-c4": "15.0",
     "odroid-m1": "15.0",
     "odroid-m1s": "15.0",
-    "odroid-n2": "15.0",
+    "odroid-n2": "14.2",
     "odroid-xu4": "15.0",
     "generic-x86-64": "15.0",
     "generic-aarch64": "15.0",


### PR DESCRIPTION
In #416 we reverted to 14.2 but not in the beta channel. Revert it too so it doesn't break for anyone in beta.