### PR TITLE
Supervisor stable to `2025.05.3`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2025.05.1",
+  "supervisor": "2025.05.3",
   "homeassistant": {
     "default": "2025.5.3",
     "qemux86": "2025.5.3",


### PR DESCRIPTION
Changelog https://github.com/home-assistant/supervisor/releases/tag/2025.05.3 and Changelog https://github.com/home-assistant/supervisor/releases/tag/2025.05.2