### PR TITLE
Supervisor stable to `2025.05.5`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2025.05.3",
+  "supervisor": "2025.05.5",
   "homeassistant": {
     "default": "2025.6.0",
     "qemux86": "2025.6.0",


### PR DESCRIPTION
[Changelog 2025.05.5](https://github.com/home-assistant/supervisor/releases/tag/2025.05.5) and [Changelog 2025.05.4](https://github.com/home-assistant/supervisor/releases/tag/2025.05.4)