### PR TITLE
Supervisor stable to `2025.06.1`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2025.05.5",
+  "supervisor": "2025.06.1",
   "homeassistant": {
     "default": "2025.6.1",
     "qemux86": "2025.6.1",


### PR DESCRIPTION
[Changelog 2025.06.0](https://github.com/home-assistant/supervisor/releases/tag/2025.06.0) and [Changelog 2025.06.1](https://github.com/home-assistant/supervisor/releases/tag/2025.06.1)