### PR TITLE
Grant git permissions to the temporary directory

### DIFF
--- a/apparmor_beta.txt
+++ b/apparmor_beta.txt
@@ -85,6 +85,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
     /** r,
     /lib/* mr,
     /data/addons/** lrw,
+    /data/tmp/** lrw,
     /usr/local/lib/** mr,
 
     capability dac_override,

--- a/apparmor_dev.txt
+++ b/apparmor_dev.txt
@@ -85,6 +85,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
     /** r,
     /lib/* mr,
     /data/addons/** lrw,
+    /data/tmp/** lrw,
     /usr/local/lib/** mr,
 
     capability dac_override,

--- a/apparmor_stable.txt
+++ b/apparmor_stable.txt
@@ -85,6 +85,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
     /** r,
     /lib/* mr,
     /data/addons/** lrw,
+    /data/tmp/** lrw,
     /usr/local/lib/** mr,
 
     capability dac_override,


### PR DESCRIPTION
Since https://github.com/home-assistant/supervisor/pull/5987 the Supervisor clones add-on store into a temporary directory if corruptions are detected. This adds the necessary permissions to the AppArmor profiles.

Fixes: https://github.com/home-assistant/supervisor/issues/6047