### PR TITLE
Supervisor stable to `2025.08.1`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2025.07.3",
+  "supervisor": "2025.08.1",
   "homeassistant": {
     "default": "2025.8.1",
     "qemux86": "2025.8.1",


### PR DESCRIPTION
- [Changelog 2025.08.0](https://github.com/home-assistant/supervisor/releases/tag/2025.08.0)
- [Changelog 2025.08.1](https://github.com/home-assistant/supervisor/releases/tag/2025.08.1)