### PR TITLE
Bump audio plugin to 2025.08.0 on stable

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -65,7 +65,7 @@
   "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2025.06.0",
   "dns": "2025.08.0",
-  "audio": "2025.02.0",
+  "audio": "2025.08.0",
   "multicast": "2025.08.0",
   "observer": "2025.02.0",
   "images": {


### PR DESCRIPTION
- [Audio plug-in 2025.08.0](https://github.com/home-assistant/plugin-audio/releases/tag/2025.08.0)