### PR TITLE
Bump CLI plugin to 2025.08.1 on stable

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -63,7 +63,7 @@
     "3": "3.13"
   },
   "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
-  "cli": "2025.06.0",
+  "cli": "2025.08.1",
   "dns": "2025.08.0",
   "audio": "2025.02.0",
   "multicast": "2025.08.0",


### PR DESCRIPTION
- [CLI plug-in 2025.08.0](https://github.com/home-assistant/plugin-cli/releases/tag/2025.08.0)
- [CLI plug-in 2025.08.1](https://github.com/home-assistant/plugin-cli/releases/tag/2025.08.1)