### PR TITLE
Supervisor stable to `2025.08.3`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2025.08.1",
+  "supervisor": "2025.08.3",
   "homeassistant": {
     "default": "2025.8.3",
     "qemux86": "2025.8.3",


### PR DESCRIPTION
- [Changelog 2025.08.2](https://github.com/home-assistant/supervisor/releases/tag/2025.08.2)
- [Changelog 2025.08.3](https://github.com/home-assistant/supervisor/releases/tag/2025.08.3)

Most notably, this will stop auto-updating Supervisor on systems running on Home Assistant OS older than 12.0 (see https://github.com/home-assistant/supervisor/pull/6098).