### PR TITLE
Supervisor stable to `2025.09.0`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2025.08.3",
+  "supervisor": "2025.09.0",
   "homeassistant": {
     "default": "2025.9.1",
     "qemux86": "2025.9.1",


### PR DESCRIPTION
- [Changelog 2025.09.0](https://github.com/home-assistant/supervisor/releases/tag/2025.09.0)