### PR TITLE
Pin SHA for all github actions

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -97,7 +97,7 @@ jobs:
           cosign-release: ${{ env.COSIGN_VERSION }}
 
       - name: Setup Python version ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
Pinning Github Actions:

* Done by a tool https://github.com/Skipants/update-action-pins
* Also removing sigstore/cosign tracking bleeding edge main