### PR TITLE
Supervisor stable to `2025.10.0`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2025.09.3",
+  "supervisor": "2025.10.0",
   "homeassistant": {
     "default": "2025.10.0",
     "qemux86": "2025.10.0",


### PR DESCRIPTION
This is mostly a bug fix release, mainly aiming to address https://github.com/home-assistant/supervisor/pull/6225.

* [Changelog 2025.10.0](https://github.com/home-assistant/supervisor/releases/tag/2025.10.0)