### PR TITLE
Supervisor stable to `2026.04.0`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.03.3",
+  "supervisor": "2026.04.0",
   "homeassistant": {
     "default": "2026.4.2",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
With this release Supervisor enables IPv6 on the internal hassio Docker network by default for all installations. The migration happens automatically on the next system reboot. This release also continues the rename from "add-ons" to "apps" across user-facing strings, and makes custom app builds work without a build.yaml file. On top of that there are smaller improvements around Supervisor auto-updates, a fix to wait for systemd-timesyncd to fully stop before setting the system time, and more reliable error reporting during backup creation. Various other bug fixes, cleanup and refactoring help to improve code quality.

- [2026.04.0 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.04.0)