### PR TITLE
Enable D-Bus in AppArmor profile in beta/dev

### DIFF
--- a/apparmor_beta.txt
+++ b/apparmor_beta.txt
@@ -6,6 +6,8 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/python>
 
+  dbus,
+
   network unix stream,
   network inet stream,
   network inet6 stream,

--- a/apparmor_dev.txt
+++ b/apparmor_dev.txt
@@ -6,6 +6,8 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/python>
 
+  dbus,
+
   network unix stream,
   network inet stream,
   network inet6 stream,


### PR DESCRIPTION
On AppArmor enabled host kernel with D-Bus support (e.g. Ubuntu in devcontainer), AppArmor by default denies any D-Bus communication. Simply allow allow D-Bus communication by adding a policy for D-Bus. This seems to cause no harm on Home Assistant OS (tested on recent version and all the way back to HAOS 9.3).

Ultimately we probably want to add a more fine grained configuration. But let's defer that to when AppArmor D-Bus mediation is actually available on Home Assistant OS.