### PR TITLE
Supervisor stable to `2026.04.2`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.04.0",
+  "supervisor": "2026.04.2",
   "homeassistant": {
     "default": "2026.4.4",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
This Supervisor version has lots of under the hood changes without much user influence just yet: Feature flags allow us to develop the new API v2 and test out the Unix socket communication with Core. Both flags are disabled by default still. Effective changes/improvements in this release focus in three main areas: 

- Improved exception handling (several exceptions are not declared as `APIError` so they get returned as http API error gracefully. We now log errors and send them to Sentry, if enabled, which are not APIErrors. This is part of ongoing exception handling improvements).
- Refactored Supervisor connectivity check: Checking connectivity is now queued if the request comes from a source where we assume connectivity really changed (e.g. from NetworkManager). This should lead to less situations where Supervisor get stuck claiming no Internet when in reality connectivity came back.
- Refactored communication with Home Assistant Core: Besides the new Unix socket support, which is still behind a feature flag, this release also includes improved http API/WebSocket connection handling with Core for both proxy and Supervisor's own calls (improved error handling, shared and improved authentication logic).


## Changelogs

- [2026.04.1 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.04.1)
- [2026.04.2 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.04.2)