### PR TITLE
Supervisor stable to `2026.05.0`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.04.2",
+  "supervisor": "2026.05.0",
   "homeassistant": {
     "default": "2026.5.0",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
With this Supervisor release Unix socket communication will be the default when upgrading to Home Assistant Core 2026.5.1. Furthermore it includes a bug fix which caused backups to not correctly restore the Core version in the backup (Supervisor rolled back to the already installed Core version by accident). Finally it gets rid of excessive warnings related to WebSocket communication with Core (message level lowered back to debug as before).

## Changelogs

- [2026.05.0 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.05.0)