### PR TITLE
Revert "Bump supervisor to 2026.05.1.dev2005"

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -1,6 +1,6 @@
 {
   "channel": "dev",
-  "supervisor": "2026.05.1.dev2005",
+  "supervisor": "2026.05.1.dev2006",
   "homeassistant": {
     "default": "2026.6.0.dev202605180321",
     "qemux86-64": "2026.6.0.dev202605180321",


### PR DESCRIPTION
This reverts commit e2b2cc7a0a4e1d210f821b7f9a1514be1d58ce56.

Build of 2026.05.1.dev2005 got restarted, but 2026.05.1.dev2006 is newer and contains the latest Supervisor PR
https://github.com/home-assistant/supervisor/pull/6854.