### PR TITLE
Supervisor stable to `2026.05.1`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.05.0",
+  "supervisor": "2026.05.1",
   "homeassistant": {
     "default": "2026.5.4",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
This is mostly a bugfix and cleanup release. Most notably, it fixes spurious system restart triggered by the hardware watchdog due to systemd being blocked by NFS mounts. Some exceptions which surfaced the API untranslated received now proper translation keys. A few improved Supervisor error and warning log messages for clarity (e.g. exit code of apps). A couple of fixes of blocking I/O in event loop raised by Blockbuster.


## Changelogs

- [2026.05.1 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.05.1)