### PR TITLE
Add permissions for /data/apps to beta/dev AppArmor profile

### DIFF
--- a/apparmor_beta.txt
+++ b/apparmor_beta.txt
@@ -71,6 +71,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
     /** r,
     /lib/* mr,
     /data/addons/** lrw,
+    /data/apps/** lrw,
     /data/tmp/** lrw,
     /usr/local/lib/** mr,
 

--- a/apparmor_dev.txt
+++ b/apparmor_dev.txt
@@ -71,6 +71,7 @@ profile hassio-supervisor flags=(attach_disconnected,mediate_deleted) {
     /** r,
     /lib/* mr,
     /data/addons/** lrw,
+    /data/apps/** lrw,
     /data/tmp/** lrw,
     /usr/local/lib/** mr,
 


### PR DESCRIPTION
In home-assistant/supervisor#6865, Supervisor migrated to and started using /data/apps instead of /data/addons. Add permissions for this folder to the AppArmor profile, otherwise it fails with errors like:

AVC apparmor="DENIED" operation="mkdir" class="file" profile="hassio-supervisor///usr/bin/git" name="/data/apps/git/5c53de3b/" pid=1849 comm="git" requested_mask="c" denied_mask="c" fsuid=0 ouid=0