### PR TITLE
Supervisor stable to `2026.06.1`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.05.1",
+  "supervisor": "2026.06.1",
   "homeassistant": {
     "default": "2026.6.2",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
This release contains mainly features and improvements related to the upcomming Home Assistant OS 18 release: It coordinates shutdowns with OS better, relays update information for Raspberry Pi firmwares and shows logs for renamed services (hassos -> haos).

Besides that there are some improvements for apps: The default app state on startup is now less confusing (stopped instead of unknown) and apps exiting with something other than zero is explicitly logged (since it also shows in the status). Furthermore the update renames some of the directories on disk from `addon` to `app`.

2026.06.0 is been on beta channel since last week, and with 2026.06.1 we addressed some bugs.


## Changelogs

- [2026.06.0 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.06.0)
- [2026.06.1 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.06.1)