### PR TITLE
Supervisor stable to `2026.06.2`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.06.1",
+  "supervisor": "2026.06.2",
   "homeassistant": {
     "default": "2026.6.3",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
This is mostly a bug fix release with some small code base cleanups as well. Main reason to release it before the upcoming Home Assistant OS release 18 is the`ha os import` bug fix.

## Changelogs

- [2026.06.2 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.06.2)