### PR TITLE
Revert to HAOS 17.3 for ODROID-N2

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -37,7 +37,7 @@
     "odroid-c4": "18.0",
     "odroid-m1": "18.0",
     "odroid-m1s": "18.0",
-    "odroid-n2": "18.0",
+    "odroid-n2": "17.3",
     "generic-x86-64": "18.0",
     "generic-aarch64": "18.0",
     "khadas-vim3": "18.0"


### PR DESCRIPTION
Several reports of boot issues/boot partition corruption after HAOS 18.0 upgrade: https://github.com/home-assistant/operating-system/issues/4788. Not all systems are affected as our test systems don't appear to suffer from the problem. Let's revert until more details are known.