### PR TITLE
Revert to HAOS 17.3 for ODROID-N2

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -37,7 +37,7 @@
     "odroid-c4": "18.1",
     "odroid-m1": "18.1",
     "odroid-m1s": "18.1",
-    "odroid-n2": "18.1",
+    "odroid-n2": "17.3",
     "generic-x86-64": "18.1",
     "generic-aarch64": "18.1",
     "khadas-vim3": "18.1"


### PR DESCRIPTION
Several reports of boot issues/boot partition corruption after HAOS 18.0/18.1 upgrade: https://github.com/home-assistant/operating-system/issues/4788. Even though only few systems seems affected, now that we have a fix for it let's skip the HAOS 18.1 update for ODROID-N2.