### PR TITLE
Supervisor stable to `2026.07.3`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.06.2",
+  "supervisor": "2026.07.3",
   "homeassistant": {
     "default": "2026.7.2",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
The main change in this release is the new OS update behavior: Home Assistant OS updates no longer reboot the system automatically. Instead, the update is installed in the background and a repair is created asking for a reboot, so users can pick a convenient moment to activate the new version. 

Besides that, this release improves port conflict detection and resolution across Core and apps, adds new mapping options for app configs, and continues the addon to app rename under the hood (groundwork for renaming the Docker containers of apps in an upcoming release). Configuration options of apps are now hidden from other apps unless they have elevated privileges. On the OS side, a failing filesystem check during boot now marks the system unhealthy, and failures of other system services are surfaced as repairs.

2026.07.0 has been on the beta channel since the beginning of July. The follow-up releases 2026.07.1 through 2026.07.3 addressed bugs found during beta, mainly around the new pending OS update tracking.

## Changelogs

- [2026.07.0 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.07.0)
- [2026.07.1 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.07.1)
- [2026.07.2 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.07.2)
- [2026.07.3 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.07.3)