### PR TITLE
Supervisor stable to `2026.07.5`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.07.3",
+  "supervisor": "2026.07.5",
   "homeassistant": {
     "default": "2026.7.4",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
This release contains more renaming from add-on to apps. One of the notable changes is the underlying container names now start with `app_` instead of `addon_` (existing/running containers get renamed at runtime). Job names, backup/restore job stages, and error metadata were migrated to the new app/apps naming as well, with compatibility shims keeping the legacy API responses intact. A new WebSocket v2 jobs compatibility feature toggle lets the frontend opt into the new job names.

This release makes Supervisor pull the Core connection parameters: whenever a connection to Core is established, fetch Core's live HTTP server configuration from the new socket-only /api/core/http_config endpoint (https://github.com/home-assistant/core/pull/176976) and update the stored port and SSL settings from it. This is more robust then the previous option call from Core.

Besides that, this release brings a number of fixes around apps and the store: ports declared in an app's configuration stay visible after customizing them, the port-conflict repair is now always fixable, and corrupt store repositories can be reset from a repair instead of leaving the store broken. Adding a duplicate store repository now returns a proper API error, and repository URLs are stripped of credentials before being sent to Sentry. Mount handling got fixes as well: `media` and `share` mounts should no longer stay empty after a mount reload, and local data is checked before a mount is added or updated.

On the system side, network connections are no longer unnecessarily re-activated in full when nothing relevant changed, the Core API proxy no longer breaks multipart uploads by stripping the boundary from the Content-Type header, and Supervisor now enters the STOPPING state before answering the restart API call. The preloaded jemalloc allocator has been replaced by PYTHONMALLOC=mimalloc. Home Assistant Core versions that already understand version_pending now get the real OS version reported, which pairs with the pending OS update tracking introduced in 2026.07.0.

2026.07.4 has been on the beta channel since last week. The follow-up releases 2026.07.5 mainly adds the pull of http configuration 

## Changelogs

- [2026.07.4 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.07.4)
- [2026.07.5 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.07.5)