### PR TITLE
Supervisor stable to `2026.08.0`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.07.5",
+  "supervisor": "2026.08.0",
   "homeassistant": {
     "default": "2026.8.3",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
The most notable part of this release is a hardening of the Supervisor API surface against apps. Two loopholes allowed an app to reach Supervisor APIs with more privileges than its declared `hassio_api`/`hassio_role`. `hassio` command types are now rejected with a Core-shaped `unauthorized` result, while the connection stays usable for regular Core calls (#7123).

This release also continues the add-on to app renaming, now covering the resolution center: add-on issue types and check slugs use app-based naming, with v1/v2 terminology shims keeping the existing REST and WebSocket API responses intact.

On mounts, a blocking local data directory no longer silently prevents a `media`/`share` mount from being created. The condition is surfaced as a new `mount_target_not_empty` issue with a `move_local_data` fixup, which moves the data aside into a user-accessible `<name>_local_recovery` folder instead of deleting it, and then reloads the mount. Storage usage can now also be reported per mount through the parameterized `GET /host/disks/{disk}/usage` endpoint.

The default port for Core/landingpage changed to 80, which is what the CLI banner shows while the landing page is running (no `homeassistant.json` exists at that point yet). Existing installations keep their port, since the previous default gets persisted on Supervisor restart. The API URL now also omits the port when it is the scheme's default, so no more `:80`/`:443` suffixes.

Further fixes: a user-overridden Core image is respected on install and update, updating an app uses the store version's architecture, image references are parsed using Docker's own domain splitting logic, and lost `systemd-journal-gatewayd` connections are handled gracefully.

2026.08.0 has been on the beta channel since August 19th.

## Changelogs

- [2026.08.0 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.08.0)