### PR TITLE
Bump plugin-cli to 2026.08.0 on stable

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -58,7 +58,7 @@
     "3": "3.13"
   },
   "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
-  "cli": "2026.06.0",
+  "cli": "2026.08.0",
   "dns": "2026.08.0",
   "audio": "2026.08.0",
   "multicast": "2026.08.0",


### PR DESCRIPTION
* https://github.com/home-assistant/plugin-cli/releases/tag/2026.08.0