### PR TITLE
Supervisor stable to `2026.09.0`

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "supervisor": "2026.08.0",
+  "supervisor": "2026.09.0",
   "homeassistant": {
     "default": "2026.9.1",
     "qemux86": "2025.11.3",


### PR DESCRIPTION
The most notable change in this release is that network mounts are now handled by systemd automount units, letting the kernel activate and recover a mount on access instead of Supervisor keeping mounts healthy itself. Media and share mounts also live directly at their path inside the containers (`/media/<name>`, `/share/<name>`), without the extra bind mount layer in between. This addresses a whole class of mount problems we have been chasing: an unreachable share can no longer wedge the host into a watchdog reset, writing to a share while it is down fails instead of quietly filling up the local disk, and outages now recover on their own once the server is back, including the repair Supervisor raised for them.

Second, Home Assistant Core's HTTP port is now held during boot until Core starts. Apps with `startup: system` or `startup: services` start before Core, and if one of them took port 8123, Core did not come up at all, leaving the user without a UI and no way out short of terminal access. Now the conflicting app is the one that fails, which surfaces the existing port conflict repair.

Third, corrupt Docker image layers can be recovered from. Since layers are shared between images, removing and re-pulling a single image usually does not help, so the new `POST /docker/reset-storage` wipes all of Docker's storage on the next boot and asks for a reboot. All container images are downloaded again afterwards, while Home Assistant and app data are kept. The CLI exposes this as `ha docker reset-storage`, so it no longer requires OS shell access. It needs HAOS 18.3 and returns 404 on older OS versions.

Applying a repair whose fixup failed used to report success, so the repair disappeared from the UI while the issue was still there. Such failures now surface as an error and the repair stays visible.

Two backend-only additions round this out, both without a consumer yet: an API to manage the SSH keys for the Home Assistant OS debug console, and Docker-given totals plus a one-shot mode in the `/stats` API. Deprecated fields were also dropped from the v2 apps, supervisor and backups endpoints, with v1 unchanged.

2026.09.0 has been on the beta channel since September 1st.

## Changelogs

- [2026.09.0 Changelog](https://github.com/home-assistant/supervisor/releases/tag/2026.09.0)