### PR TITLE
Bump plugin-dns to 2026.09.0 on stable

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -59,7 +59,7 @@
   },
   "ota": "https://os-artifacts.home-assistant.io/{version}/{os_name}_{board}-{version}.raucb",
   "cli": "2026.08.0",
-  "dns": "2026.08.0",
+  "dns": "2026.09.0",
   "audio": "2026.08.0",
   "multicast": "2026.08.0",
   "observer": "2026.08.0",


### PR DESCRIPTION
* https://github.com/home-assistant/plugin-dns/releases/tag/2026.09.0